### PR TITLE
Compression support

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -26,10 +26,12 @@ uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
 version = "0.5.0"
 
 [[CodecLz4]]
-deps = ["BinDeps", "Compat", "Libdl", "TranscodingStreams"]
-git-tree-sha1 = "c4f81e9f2a3334d9e7c6ead21e8c97d6263ad304"
+deps = ["BinDeps", "Compat", "TranscodingStreams"]
+git-tree-sha1 = "ab4cd235e5fa915353b3349509f56ee03cd0cfec"
+repo-rev = "master"
+repo-url = "https://github.com/invenia/CodecLz4.jl.git"
 uuid = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
-version = "0.0.2"
+version = "0.0.2+"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "Pkg", "Test", "TranscodingStreams"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,16 +1,93 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[BinDeps]]
+deps = ["Compat", "Libdl", "SHA", "URIParser"]
+git-tree-sha1 = "12093ca6cdd0ee547c39b1870e0c9c3f154d9ca9"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.8.10"
+
+[[BinaryProvider]]
+deps = ["Libdl", "Pkg", "SHA", "Test"]
+git-tree-sha1 = "b530fbeb6f41ab5a83fbe3db1fcbe879334bcd2d"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.4.2"
+
+[[BufferedStreams]]
+deps = ["Compat", "Pkg", "Test"]
+git-tree-sha1 = "5d55b9486590fdda5905c275bb21ce1f0754020f"
+uuid = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
+version = "1.0.0"
+
+[[CodecBzip2]]
+deps = ["BinDeps", "Libdl", "Test", "TranscodingStreams", "WinRPM"]
+git-tree-sha1 = "6baeaa476f6495c282829abdef0ecdca18d33bbe"
+uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+version = "0.5.0"
+
+[[CodecLz4]]
+deps = ["BinDeps", "Compat", "Libdl", "TranscodingStreams"]
+git-tree-sha1 = "c4f81e9f2a3334d9e7c6ead21e8c97d6263ad304"
+uuid = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
+version = "0.0.2"
+
+[[CodecZlib]]
+deps = ["BinaryProvider", "Libdl", "Pkg", "Test", "TranscodingStreams"]
+git-tree-sha1 = "83cb3d65c37ea1364c2d5bf7bcea41843ba645dc"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.5.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "ae262fa91da6a74e8937add6b613f58cd56cdad4"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.1.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
 [[Distributed]]
 deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[HTTPClient]]
+deps = ["Compat", "LibCURL"]
+git-tree-sha1 = "161d5776ae8e585ac0b8c20fb81f17ab755b3671"
+uuid = "0862f596-cf2d-50af-8ef4-f2be67dfa83f"
+version = "0.2.1"
 
 [[InteractiveUtils]]
 deps = ["LinearAlgebra", "Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[LibCURL]]
+deps = ["BinaryProvider", "Compat", "Libdl", "Pkg"]
+git-tree-sha1 = "f7c4fd37291207ec6bd4b7b9abfc512d4bb8b88e"
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.3.1"
+
+[[LibExpat]]
+deps = ["Compat", "Pkg"]
+git-tree-sha1 = "fde352ec13479e2f90e57939da2440fb78c5e388"
+uuid = "522f3ed2-3f36-55e3-b6df-e94fee9b0c07"
+version = "0.5.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Libz]]
+deps = ["BufferedStreams", "Random", "Test"]
+git-tree-sha1 = "d405194ffc0293c3519d4f7251ce51baac9cc871"
+uuid = "2ec943e9-cfe8-584d-b93d-64dcb6d567b7"
+version = "1.0.0"
 
 [[LinearAlgebra]]
 deps = ["Libdl"]
@@ -23,16 +100,71 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TranscodingStreams]]
+deps = ["DelimitedFiles", "Pkg", "Random", "Test"]
+git-tree-sha1 = "a34a2d588e2d2825602bf14a24216d5c8b0921ec"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.8.1"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[WinRPM]]
+deps = ["BinDeps", "Compat", "HTTPClient", "LibExpat", "Libdl", "Libz", "SHA", "URIParser"]
+git-tree-sha1 = "023faa2430b4ad3f9cf073c03cf100d80630fb6d"
+uuid = "c17dfb99-b4f7-5aad-8812-456da1ad7187"
+version = "0.4.0"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,10 @@ authors = ["Corneliu Cofaru <cornel@oxoaresearch.com>"]
 version = "0.0.1"
 
 [deps]
+CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+CodecLz4 = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"

--- a/README.md
+++ b/README.md
@@ -229,4 +229,4 @@ This code has an MIT license and therefore it is free.
 
 [2] https://en.wikipedia.org/wiki/Cache_replacement_policies
 
-For other caching solutions,  check out also [LRUCache.jl](https://github.com/JuliaCollections/LRUCache.jl) and [Memoize.jl](https://github.com/simonster/Memoize.jl)
+For other caching solutions,  check out also [LRUCache.jl](https://github.com/JuliaCollections/LRUCache.jl), [Memoize.jl](https://github.com/simonster/Memoize.jl) and [Memoize.jl](https://github.com/colinfang/Memoize.jl) as well as [Anamnesis.jl](https://github.com/ExpandingMan/Anamnesis.jl)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A minimalistic approach to method caching in Julia.
 
 ## Introduction
 
-This package provides a simple programming interface to caching the function output (i.e. memoization) either to memory or to disk. To this purpose it has a simplistic API that exposes functionality for creating cache structures and accessing, writing and synchronizing these to disk. Since this a work-in-progress, there are bound to be rough edges and little to no documentation. However, the interface is accessible enough to be productively employed at this stage.
+This package provides a simple programming interface to caching the function output (i.e. memoization) either to memory or to disk. To this purpose it has a simplistic API that exposes functionality for creating cache structures and accessing, writing and synchronizing these to disk. Compression is supported through [TranscodingStreams.jl](https://github.com/bicycle1885/TranscodingStreams.jl) codecs. Since this a work-in-progress, there are bound to be rough edges and little to no documentation. However, the interface is accessible enough to be productively employed at this stage.
 
 
 
@@ -202,11 +202,9 @@ More usage examples can be found in the `test/runtests.jl` file.
 
 Some limitations of this package that will have to be taken into consideration are:
 - no support for a maximum size of the cache or replacement policy; only a full deletion of the cache is supported
-- no support for Julia v0.6 and lower
 - the cache access is not type-stable unless types are explicitly provided i.e. `@memcache foo::MyType`
 - the caching mechanism is unaware of any syste-wide limitations on either memory or disk (TODO)
 - multithreading/parallelism is not explicitly supported (TODO)
-- compression is not supported (TODO)
 - the `@memcache` and `@diskcache` do not support entire function definitions i.e. `@memcache foo(x)=x` or `@memcache x->x+1` (TODO)
 
 

--- a/src/Caching.jl
+++ b/src/Caching.jl
@@ -6,6 +6,8 @@ module Caching
 
 using Random
 using Serialization
+using TranscodingStreams
+using CodecZlib, CodecBzip2, CodecLz4
 import Base: show, empty!
 
 abstract type AbstractCache end
@@ -23,8 +25,9 @@ export AbstractCache,
     @persist!,
     @empty!
 
-    include("hash.jl")
     include("memcache.jl")
     include("diskcache.jl")
+    include("hash.jl")
     include("utils.jl")
+    include("compression.jl")
 end  # module

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -1,0 +1,41 @@
+# Function that retrieves one entry from a stream
+function _load_disk_cache_entry(io::IO, pos_start::Int, pos_end::Int;
+                                decompressor=Noop)
+    seek(io, pos_start)
+    cbuf = read(io, pos_end-pos_start)
+    buf = transcode(decompressor, cbuf)
+    datum = deserialize(IOBuffer(cbuf))
+    return datum
+end
+
+
+# Function that stores one entry to a stream
+function _store_disk_cache_entry(io::IO, pos::Int, datum;
+                                 compressor=Noop)
+    seek(io, pos)
+    buf = IOBuffer()
+    serialize(buf, datum)
+    posbuf = position(buf)
+    cbuf = transcode(compressor, buf.data[1:posbuf])
+    write(io, cbuf)
+    return position(io)
+end
+
+
+function _get_transcoders(filename::T="") where T<:AbstractString
+    ext = split(filename, ".")[end]
+    if ext == "lz4"
+        compressor = LZ4Compressor
+        decompressor = LZ4Decompressor
+    elseif ext == "bz2" || ext == "bzip2"
+        compressor = Bzip2Compressor
+        decompressor = Bzip2Decompressor
+    elseif ext == "gz" || ext == "gzip"
+        compressor = GzipCompressor
+        decompressor = GzipDecompressor
+    else
+        compressor = Noop  # no compression
+        decompressor = Noop  # no compression
+    end
+    return compressor, decompressor
+end

--- a/src/diskcache.jl
+++ b/src/diskcache.jl
@@ -39,7 +39,6 @@ end
 
 
 # Function that retrieves one entry from a stream
-# TODO(Corneliu): Implement
 function _load_disk_cache_entry(io::T where T<:IO, pos::Int)
     seek(io, pos)
     datum = deserialize(io)
@@ -48,7 +47,6 @@ end
 
 
 # Function that stores one entry to a stream
-# TODO(Corneliu): Implement
 function _store_disk_cache_entry(io::T where T<:IO, pos::Int, datum)
     seek(io, pos)
     serialize(io, datum)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,8 +250,31 @@ end
     @test buf == buf2  # sanity check
 end
 
+# Compression
+@testset "Compression" begin
+    files = ["somefile.bin",
+             "somefile.bin.gz",
+             "somefile.bin.gzip",
+             "somefile.bin.bz2",
+             "somefile.bin.bzip2",
+            ]
+    for _file in files
+        global foo(x) = x
+        dc = @eval @diskcache foo $_file
+        dc(1)
+        try
+            @persist! dc
+            @empty! dc true
+            @test true
+        catch
+            @test false
+        end
+    end
+end
+
+
 # show methods
-@testset "show" begin
+@testset "Show methods" begin
     buf = IOBuffer()
     foo(x) = x
     mc = @memcache foo


### PR DESCRIPTION
- [x] Added compression support through `TranscodingStreams` for **bzip2**, **lz4**, and **gzip**,

Remark: Because compression is used after serialization, in many cases it is not useful (i.e. slower and size of the file is larger)